### PR TITLE
Add screenshot functionality to pdf creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "bootstrap": "^5.2.3",
         "d3": "^7.8.5",
         "file-saver": "^2.0.5",
+        "html2canvas": "^1.4.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.11.1",
@@ -5766,6 +5767,14 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -6525,6 +6534,14 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
       "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/css-loader": {
       "version": "6.8.1",
@@ -9088,6 +9105,18 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
@@ -14768,6 +14797,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -15210,6 +15247,14 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "bootstrap": "^5.2.3",
     "d3": "^7.8.5",
     "file-saver": "^2.0.5",
+    "html2canvas": "^1.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.11.1",

--- a/src/assignments/assignment.tsx
+++ b/src/assignments/assignment.tsx
@@ -3,6 +3,7 @@ import { saveAs } from 'file-saver';
 import { pdf } from '@react-pdf/renderer';
 import { Answer } from './answer';
 import { AssignmentDocument } from './pdfDocument';
+import html2canvas from 'html2canvas';
 
 
 interface AssignmentProps {
@@ -20,9 +21,16 @@ export const Assignment: React.FC<AssignmentProps>  = (
             <AssignmentDocument
                 questions={questions}
                 answers={answers}
+                screenshot={''}
             />
         )).toBlob();
         saveAs(blob, 'test-pdfs');
+    };
+
+    const generateScreenshot = async() => {
+        await html2canvas(document.querySelector('#capture')).then(canvas => {
+            const dataURL = canvas.toDataURL('image/png');
+        });
     };
 
     const handleLocalStorage = () => {
@@ -63,6 +71,11 @@ export const Assignment: React.FC<AssignmentProps>  = (
                         onClick={() => void generatePdfDocument()}
                         className={'btn btn-primary btn-statify'}>
                                 Create PDF
+                    </button>
+                    <button
+                        onClick={() => void generateScreenshot()}
+                        className={'btn btn-primary btn-statify'}>
+                                Create Screenshot
                     </button>
                 </div>
             </div>

--- a/src/assignments/assignment.tsx
+++ b/src/assignments/assignment.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { saveAs } from 'file-saver';
 import { pdf } from '@react-pdf/renderer';
 import { Answer } from './answer';
@@ -14,22 +14,27 @@ interface AssignmentProps {
 export const Assignment: React.FC<AssignmentProps>  = (
     {questions}
 ) => {
-    const [answers, setAnswers] = React.useState({});
+    const [answers, setAnswers] = useState({});
+    const [screenshot, setScreenshot] = useState<string>();
 
     const generatePdfDocument = async() => {
         const blob = await pdf((
             <AssignmentDocument
                 questions={questions}
                 answers={answers}
-                screenshot={''}
+                screenshot={screenshot}
             />
         )).toBlob();
         saveAs(blob, 'test-pdfs');
     };
 
     const generateScreenshot = async() => {
-        await html2canvas(document.querySelector('#capture')).then(canvas => {
+        await html2canvas(document.querySelector('#capture'), {
+            backgroundColor: '#00000'
+        }).then(canvas => {
+
             const dataURL = canvas.toDataURL('image/png');
+            setScreenshot(dataURL);
         });
     };
 
@@ -45,7 +50,6 @@ export const Assignment: React.FC<AssignmentProps>  = (
         <>
             <div className='col-md-9'>
                 <h2>Questions</h2>
-
                 {questions.map((question, index) => {
                     return (
                         <div key={index}>
@@ -68,14 +72,15 @@ export const Assignment: React.FC<AssignmentProps>  = (
                         className={'form-label'}>3. Build a report
                     </label> <br />
                     <button
+                        onClick={() => void generateScreenshot()}
+                        className={'btn btn-primary btn-statify me-2'}>
+                                Screenshot Graph
+                    </button>
+                    <button
+                        disabled={!screenshot}
                         onClick={() => void generatePdfDocument()}
                         className={'btn btn-primary btn-statify'}>
                                 Create PDF
-                    </button>
-                    <button
-                        onClick={() => void generateScreenshot()}
-                        className={'btn btn-primary btn-statify'}>
-                                Create Screenshot
                     </button>
                 </div>
             </div>

--- a/src/assignments/pdfDocument.tsx
+++ b/src/assignments/pdfDocument.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-    Document, Page, Text, StyleSheet
+    Document, Page, Text, StyleSheet, Image
 } from '@react-pdf/renderer';
 
 // Create styles
@@ -25,22 +25,33 @@ const styles = StyleSheet.create({
     question: {
         fontSize: 13,
         marginBottom: 5
+    },
+    image: {
+        marginVertical: 15,
+        marginHorizontal: 100,
     }
 });
 
 interface AssignmentDocumentProps {
     questions: string[];
     answers: object;
+    screenshot: any;
 }
 
 
 export const AssignmentDocument: React.FC<AssignmentDocumentProps>  = (
-    {questions, answers}
+    {questions, answers, screenshot}
 ) =>
 {
     const createQA = questions.map((question, index) => {
         return (
             <>
+                <Image
+                    style={styles.image}
+                    // eslint-disable-next-line max-len
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    src={screenshot} />
+
                 <Text style={styles.questionTitle}>
                 Question #{index + 1}
                 </Text>

--- a/src/assignments/pdfDocument.tsx
+++ b/src/assignments/pdfDocument.tsx
@@ -23,8 +23,11 @@ const styles = StyleSheet.create({
         marginBottom: 5
     },
     image: {
-        marginVertical: 100,
-        marginHorizontal: 100,
+        width: '100%',
+        height: '50%',
+        borderColor: 'black',
+        backgroundColor: 'black',
+        marginBottom: 10
     }
 });
 

--- a/src/assignments/pdfDocument.tsx
+++ b/src/assignments/pdfDocument.tsx
@@ -10,10 +10,6 @@ const styles = StyleSheet.create({
         paddingBottom: 65,
         paddingHorizontal: 35,
     },
-    viewer: {
-        width: window.innerWidth,
-        height: window.innerHeight,
-    },
     questionTitle: {
         fontSize: 15,
         marginBottom: 10
@@ -27,7 +23,7 @@ const styles = StyleSheet.create({
         marginBottom: 5
     },
     image: {
-        marginVertical: 15,
+        marginVertical: 100,
         marginHorizontal: 100,
     }
 });
@@ -35,7 +31,7 @@ const styles = StyleSheet.create({
 interface AssignmentDocumentProps {
     questions: string[];
     answers: object;
-    screenshot: any;
+    screenshot: string;
 }
 
 
@@ -46,14 +42,8 @@ export const AssignmentDocument: React.FC<AssignmentDocumentProps>  = (
     const createQA = questions.map((question, index) => {
         return (
             <>
-                <Image
-                    style={styles.image}
-                    // eslint-disable-next-line max-len
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                    src={screenshot} />
-
                 <Text style={styles.questionTitle}>
-                Question #{index + 1}
+                Question {index + 1}
                 </Text>
                 <Text style={styles.question}>
                     {question}
@@ -69,6 +59,9 @@ export const AssignmentDocument: React.FC<AssignmentDocumentProps>  = (
     return (
         <Document>
             <Page size='A4' style={styles.page}>
+                <Image
+                    style={styles.image}
+                    source={screenshot} />
                 {createQA}
             </Page>
         </Document>

--- a/src/graphForm.tsx
+++ b/src/graphForm.tsx
@@ -4,8 +4,7 @@ import { SampleDataHistogram } from './graphs/sampleDataHistogram';
 import { CumulativeSampleMean } from './graphs/sampleMeanLine';
 import { SamplingDistribution } from './graphs/distributionHistogram';
 import { Histogram } from './graphs/histogram';
-import { InstructionData } from './common';
-import { AudioFeature, Genre, toTitleCase } from './common';
+import { AudioFeature, Genre, toTitleCase, InstructionData  } from './common';
 
 interface GraphFormProps {
     genre1Field: boolean;
@@ -192,7 +191,7 @@ export const GraphForm: React.FC<GraphFormProps> = (
                                     {genresText.map((genre, index) => {
                                         return (
                                             <option key={index} value={genre}>
-                                                {genre}
+                                                {toTitleCase(genre)}
                                             </option>
                                         );
                                     })}

--- a/src/graphForm.tsx
+++ b/src/graphForm.tsx
@@ -136,7 +136,7 @@ export const GraphForm: React.FC<GraphFormProps> = (
                         + 'input on the right—check it out!'
                     )}
                 </div>
-                <div className='row'>
+                <div className='row' id='capture'>
                     {graphTypes.includes(SAMPLEDATA) && (
                         <Histogram
                             data1={data1}


### PR DESCRIPTION
* Functionality is visible at /inferential
* Separate buttons to create screenshot and then pdf.
* PDF looks like:
<img width="793" alt="Screen Shot 2023-06-29 at 4 00 34 PM" src="https://github.com/ccnmtl/statify/assets/36773036/d497efeb-8d75-4428-8513-43ddc29f6023">