### PR TITLE
Generate a legend for 2 genre graphs

### DIFF
--- a/src/common.tsx
+++ b/src/common.tsx
@@ -84,9 +84,10 @@ export const graphBins = {
     popularity: popularity
 };
 
-export const primary = 'rgba(82, 208, 80, 1.0)';
-export const secondary = 'rgba(255, 100, 100, 0.7)';
+export const PRIMARY = 'rgba(82, 208, 80, 1.0)';
+export const SECONDARY = 'rgba(255, 100, 100, 0.7)';
 export const HIGHLIGHT_1 = 'yellow';
 export const HIGHLIGHT_2 = 'rgba(255, 100, 255, 0.7)';
+export const GRAPH_BG = 'rgba(64, 64, 64, 1.0)';
 export const FONT_SIZE = 14;
 export const MARGIN = 30;

--- a/src/graphForm.tsx
+++ b/src/graphForm.tsx
@@ -3,7 +3,7 @@ import genres from '../data/trackDataByGenre.json';
 import { CumulativeSampleMean } from './graphs/sampleMeanLine';
 import { Histogram } from './graphs/histogram';
 import {
-    Genre, toTitleCase, InstructionData, primary, secondary
+    Genre, toTitleCase, InstructionData, PRIMARY, SECONDARY
 } from './common';
 import seedrandom from 'seedrandom'; // https://github.com/davidbau/seedrandom
 import { EstimatedDistribution } from './graphs/estimatedSampleDistribution';
@@ -200,7 +200,7 @@ export const GraphForm: React.FC<GraphFormProps> = (
                 <div className='row' id='capture'>
                     {graphTypes.includes(SAMPLEDATAHISTOGRAM1) && (
                         <Histogram
-                            color={primary}
+                            color={PRIMARY}
                             data1={data1}
                             data2={null}
                             genre1={genre1}
@@ -210,7 +210,7 @@ export const GraphForm: React.FC<GraphFormProps> = (
                     )}
                     {graphTypes.includes(SAMPLEDATAHISTOGRAM2) && (
                         <Histogram
-                            color={secondary}
+                            color={SECONDARY}
                             data1={data2}
                             data2={null}
                             genre1={genre2}
@@ -220,7 +220,7 @@ export const GraphForm: React.FC<GraphFormProps> = (
                     )}
                     {graphTypes.includes(SAMPLEDATAHISTOGRAMBOTH) && (
                         <Histogram
-                            color={primary}
+                            color={PRIMARY}
                             data1={data1}
                             data2={data2}
                             genre1={genre1}
@@ -245,7 +245,7 @@ export const GraphForm: React.FC<GraphFormProps> = (
                     )}
                     {graphTypes.includes(DISTRIBUTIONHISTOGRAM) && (
                         <Histogram
-                            color={primary}
+                            color={PRIMARY}
                             data1={meanData1}
                             data2={meanData2}
                             genre1={genre1}
@@ -372,7 +372,7 @@ export const GraphForm: React.FC<GraphFormProps> = (
                         <input
                             type='submit'
                             id='submit-btn'
-                            className='btn btn-primary'
+                            className='btn btn-PRIMARY'
                             value='Submit'
                         />
                     </form>

--- a/src/graphs/estimatedSampleDistribution.tsx
+++ b/src/graphs/estimatedSampleDistribution.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState } from 'react';
-import { BinData, graphBins, toTitleCase, primary, secondary } from '../common';
+import { BinData, graphBins, toTitleCase, PRIMARY, SECONDARY } from '../common';
 import { scaleLinear } from 'd3-scale';
 import { select, Selection } from 'd3-selection';
 import {
@@ -187,9 +187,9 @@ export const EstimatedDistribution: React.FC<EstimatedDistributionProps>  = (
             selection.selectAll('g').remove();
 
             generateCurve(selection, 'curve1', projection, data1, curve, fill,
-                primary, se1, mean1, x, y);
+                PRIMARY, se1, mean1, x, y);
             generateCurve(selection, 'curve2', projection, data2, curve, fill,
-                secondary, se2, mean2, x, y);
+                SECONDARY, se2, mean2, x, y);
 
             // Construct the Y-axis
             selection.append('g')

--- a/src/graphs/sampleMeanLine.tsx
+++ b/src/graphs/sampleMeanLine.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect } from 'react';
-import { BinData, graphBins, toTitleCase, primary, secondary,
+import { BinData, graphBins, toTitleCase, PRIMARY, SECONDARY,
     FONT_SIZE, MARGIN } from '../common';
 import { cumulativeMeanFunc } from './utils';
 import { line, axisBottom, axisLeft } from 'd3';
@@ -96,7 +96,7 @@ export const CumulativeSampleMean: React.FC<CumulativeSampleMeanProps>  = (
             .datum(cm)
             .attr('d', lnMkr(cm))
             .attr('fill', 'none')
-            .attr('stroke', primary)
+            .attr('stroke', PRIMARY)
             .attr('stroke-width', 2);
 
         if(data2) {
@@ -121,7 +121,7 @@ export const CumulativeSampleMean: React.FC<CumulativeSampleMeanProps>  = (
                 .datum(cm2)
                 .attr('d', lnMkr2(cm2))
                 .attr('fill', 'none')
-                .attr('stroke', secondary)
+                .attr('stroke', SECONDARY)
                 .attr('stroke-width', 2);
         }
 


### PR DESCRIPTION
The layout is a compromise of the SVG positioning. D3 doesn't allow for percentage values relative to the width of an object, nor does it create a bounding box around sub-elements. What I could do was pin the dots in the upper right hand corner and anchor the text to it so variable string length didn't matter.

Includes some minor changes to `common.tsx`, keeping with the convention of ALL-CAPS for constants.