### PR TITLE
Genre is now a dropdown with filter and sort functionality

### DIFF
--- a/cypress/e2e/comparingGenres.cy.js
+++ b/cypress/e2e/comparingGenres.cy.js
@@ -36,8 +36,14 @@ describe('Comparing Genres', () => {
     });
 
     it('Checks form', () => {
+        cy.get('[data-cy="secondGenre"]').click();
+        cy.get('[data-cy="Option2-0"]').click();
+        cy.get('[data-cy="secondGenre"]').should('contain', '5th Wave Emo');
+        cy.get('[data-cy="reset"]').click();
+        cy.get('[data-cy="secondGenre"]').should('contain', 'Select One');
+
         cy.get('#submit-btn').click();
-        cy.get('#firstGenre')
+        cy.get('#audioFeature')
             .invoke('prop', 'validationMessage')
             .should((text) => {
                 expect(text).to.contain('Please select an item in the list.');

--- a/cypress/e2e/confidenceIntervals.cy.js
+++ b/cypress/e2e/confidenceIntervals.cy.js
@@ -33,8 +33,14 @@ describe('Confidence Intervals', () => {
     });
 
     it('Checks form', () => {
+        cy.get('[data-cy="secondGenre"]').click();
+        cy.get('[data-cy="Option2-0"]').click();
+        cy.get('[data-cy="secondGenre"]').should('contain', '5th Wave Emo');
+        cy.get('[data-cy="reset"]').click();
+        cy.get('[data-cy="secondGenre"]').should('contain', 'Select One');
+
         cy.get('#submit-btn').click();
-        cy.get('#firstGenre')
+        cy.get('#audioFeature')
             .invoke('prop', 'validationMessage')
             .should((text) => {
                 expect(text).to.contain('Please select an item in the list.');

--- a/cypress/e2e/descriptive.cy.js
+++ b/cypress/e2e/descriptive.cy.js
@@ -13,9 +13,13 @@ describe('Descriptive Statistics', () => {
         cy.get('#firstGenre').scrollIntoView().should('be.visible');
         cy.get('#seed').should('exist');
         cy.get('#secondGenre').should('not.be', 'visible');
-        cy.get('#firstGenre').select('Latin', {force: true});
+        cy.get('[data-cy="firstGenre"]').click();
+        cy.get('[data-cy="Option1-0"]').click();
+        cy.get('[data-cy="firstGenre"]').should('contain', '5th Wave Emo');
         cy.get('[data-cy="SampleDataHistogram"]').should('exist');
         cy.get('#submit-btn').click();
+        cy.get('[data-cy="reset"]').click();
+        cy.get('[data-cy="firstGenre"]').should('contain', 'Select One');
     });
     it('Checks tabs', () => {
         cy.get('[data-cy="0"]').should('exist');

--- a/cypress/e2e/inferential.cy.js
+++ b/cypress/e2e/inferential.cy.js
@@ -31,13 +31,17 @@ describe('Inferential Statistics', () => {
     });
 
     it('Checks form', () => {
-        cy.get('#firstGenre').select('Latin', {force: true});
+        cy.get('[data-cy="firstGenre"]').click();
+        cy.get('[data-cy="Option1-0"]').click();
+        cy.get('[data-cy="firstGenre"]').should('contain', '5th Wave Emo');
         cy.get('#submit-btn').click();
         cy.get('#dataPoints')
             .invoke('prop', 'validationMessage')
             .should((text) => {
                 expect(text).to.contain('Please select an item in the list.');
             });
+        cy.get('[data-cy="reset"]').click();
+        cy.get('[data-cy="firstGenre"]').should('contain', 'Select One');
     });
 
     it('Tests a11y', () => {

--- a/src/genrePicker.tsx
+++ b/src/genrePicker.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect, useState } from 'react';
+import genreList from '../data/trackDataByGenre.json';
+import { toTitleCase } from './common';
+import { descending } from 'd3';
+
+interface GenreProps {
+    genre:string|undefined,
+    handler:React.MouseEventHandler<HTMLButtonElement>,
+    label:string,
+    x:number
+}
+
+export const GenrePicker: React.FC<GenreProps> = ({
+    genre, handler, label, x
+}) => {
+    const [genreNames, setGenreNames] =
+        useState<string[]>(Object.keys(genreList));
+    const [sortAsc, setSortAsc] = useState<boolean>(true);
+    const [sortedPopular, setsortedPopular] = useState<boolean>(false);
+    const [filteredGenres, setFilteredGenres] =
+        useState(Object.entries(genreList));
+
+    const sortAlphabet = function() {
+        if (sortAsc) {
+            setGenreNames(filteredGenres.map(genre => genre[0]));
+        } else {
+            setGenreNames(filteredGenres.map(genre => genre[0])
+                .sort(descending));
+        }
+    };
+
+    const handleOutClick = (
+        evt:MouseEvent
+    ): void => {
+        const element = document.getElementById('genre' + x);
+        if (evt.target !== element && !element.contains(evt.target as Node))
+        {
+            document.getElementById('genreList' + x)
+                .classList.remove('show');
+        }
+    };
+
+    window.addEventListener('click', handleOutClick);
+
+    const sortPopular = function() {
+        setGenreNames(Object.values(filteredGenres)
+            .sort((a, b) => b[1].count - a[1].count)
+            .map(genre => genre[0]));
+        setsortedPopular(true);
+    };
+
+    const handleAlphabet = (
+        evt: React.MouseEvent<HTMLElement>): void =>
+    {
+        evt.preventDefault();
+        if (sortedPopular) {
+            setsortedPopular(false);
+            sortAlphabet();
+        } else {
+            setSortAsc(!sortAsc);
+        }
+    };
+
+    const handlePopular = (
+        evt: React.MouseEvent<HTMLElement>): void =>
+    {
+        evt.preventDefault();
+        sortPopular();
+    };
+
+    const filterSearch = function(
+        evt: React.ChangeEvent<HTMLInputElement>): void {
+        setFilteredGenres(Object.entries(genreList)
+            .filter((genre) => genre[0]
+                .includes(evt.target.value.toLowerCase())));
+    };
+
+    const generateListItem = function(
+        item:string,
+        genreNumber:number,
+        index:number,
+        handler:React.MouseEventHandler<HTMLButtonElement>
+    ) {
+        return (
+            <li key={index}
+                className={`list-group-item bg-dark text-white 
+                    hover-green p-0 ${(item === genre ? 'active': '')}`}
+            >
+                <button
+                    className='btn w-100'
+                    data-cy={'Option' + genreNumber + '-' + index}
+                    onClick={handler}
+                    value={item}
+                >
+                    {toTitleCase(item)}
+                </button>
+            </li>
+        );
+    };
+
+    /* eslint-disable max-len */
+    const displaySortDirection = function() {
+        if (sortAsc) {
+            return (<>
+                A-Z
+                <span className='mx-2'></span>
+                <svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' className='bi bi-arrow-down-circle' viewBox='0 0 16 16'>
+                    <path fillRule='evenodd' d='M1 8a7 7 0 1 0 14 0A7 7 0 0 0 1 8zm15 0A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM8.5 4.5a.5.5 0 0 0-1 0v5.793L5.354 8.146a.5.5 0 1 0-.708.708l3 3a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V4.5z'/>
+                </svg>
+            </>);
+        } else {
+            return (<>
+                Z-A
+                <span className='mx-2'></span>
+                <svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' className='bi bi-arrow-up-circle' viewBox='0 0 16 16'>
+                    <path fillRule='evenodd' d='M1 8a7 7 0 1 0 14 0A7 7 0 0 0 1 8zm15 0A8 8 0 1 1 0 8a8 8 0 0 1 16 0zm-7.5 3.5a.5.5 0 0 1-1 0V5.707L5.354 7.854a.5.5 0 1 1-.708-.708l3-3a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 5.707V11.5z'/>
+                </svg>
+            </>);
+        }
+    };
+    /* eslint-enable max-len */
+
+    useEffect(() => {
+        if (sortedPopular) {
+            sortPopular();
+        } else {
+            sortAlphabet();
+        }
+    }, [filteredGenres]);
+
+    useEffect(() => {
+        sortAlphabet();
+    }, [sortAsc]);
+
+    return (
+        <div className='mb-3' id={'genre' + x}>
+            <label htmlFor={label + 'Genre'}
+                className='form-label col-12'
+            >
+                {'Genre ' + x}
+            </label>
+            <button
+                id={label + 'Genre'}
+                className='btn btn-dark
+                    text-white hover-green'
+                type='button'
+                data-bs-toggle='collapse'
+                data-bs-target={'#genreList' + x}
+                data-cy={label + 'Genre'}
+                aria-expanded='false'
+                aria-controls={'genreList' + x}
+            >
+                {genre ?
+                    toTitleCase(genre) :'Select One'}
+            </button>
+            <div
+                className='collapse p-2'
+                id={'genreList' + x}
+            >
+                <div
+                    className='row mb-2'
+                    aria-label='Sorting options'
+                >
+                    <button
+                        className='btn text-white col'
+                        onClick={handleAlphabet}
+                    >
+                        {displaySortDirection()}
+                    </button>
+                    <button
+                        className='btn text-white col'
+                        onClick={handlePopular}
+                        disabled={sortedPopular}
+                    >
+                        Popularity
+                    </button>
+                </div>
+                <input
+                    className='form-control'
+                    onChange={filterSearch}
+                    placeholder='Search'
+                    type='text' />
+                <hr />
+                <ul
+                    className='list-group'
+                    style={{
+                        height: '35rem',
+                        overflowX: 'clip',
+                        overflowY: 'scroll',
+                    }}
+                >
+                    {genreNames.map((genre, index) =>
+                        generateListItem(
+                            genre,
+                            x,
+                            index,
+                            handler
+                        )
+                    )}
+                </ul>
+            </div>
+        </div>
+    );
+};

--- a/src/main.css
+++ b/src/main.css
@@ -34,6 +34,20 @@ body
     font-size: 1.2em;
 }
 
+li button {
+    color: white!important;
+}
+
+.hover-green:hover, .hover-green:focus {
+    background-color: #37D247!important;
+}
+
+li.active
+{
+    background-color: white;
+    color: black;
+}
+
 li.no-bullet
 {
     list-style-type: none;

--- a/tests/graphForm.test.tsx
+++ b/tests/graphForm.test.tsx
@@ -1,0 +1,18 @@
+import { getDataPoints } from '../src/graphForm'
+import seedrandom from 'seedrandom'; 
+
+describe('Get Datapoints Function', () => {
+    test('The right number of datapoints are collected', () => {
+        const prng = seedrandom('12345678');
+        const points1 = getDataPoints('alternative_rock', 'tempo', 25, prng);
+        expect(points1.length).toEqual(25);
+    });
+    
+    test('A given seed generates the same datapoints', () => {
+        let prng1 = seedrandom('12345678');
+        const points1 = getDataPoints('alternative_rock', 'tempo', 25, prng1);
+        prng1 = seedrandom('12345678');
+        const points2 = getDataPoints('alternative_rock', 'tempo', 25, prng1);
+        expect(points1).toEqual(points2);
+    });
+});


### PR DESCRIPTION
In this branch:
- I updated the JSON file so it comes pre-sorted A-Z and trimmed some whitespace to save on file size.
- Because the genre dropdowns are a lot more HTML I decided to put it into a function. That makes it easier to comply with the `max-len` eslint rule in a way that is easier to read. It also prevents potential drift between the first and second genre dropdowns.
- `getDataPoints()` was migrated out of the component to be exported for testing.

Down the road:
- I want to add an EventListener to check when a user clicks out of the dropdown area so that it closes without having to click the button again. That decision was made based off of Marc's design, but I've noticed that it's a bit distracting.
- I also recommend that we restructure the right column to be outside of the left column entirely (currently it is in the same row as the graphs. If we do that we should also remove the sticky feature on the right column otherwise it will be impossible to see the bottom when the menus are expanded.  