### PR TITLE
Re-positioned p-value to avoid overlap with the title

### DIFF
--- a/src/graphs/estimatedSampleDistribution.tsx
+++ b/src/graphs/estimatedSampleDistribution.tsx
@@ -218,8 +218,11 @@ export const EstimatedDistribution: React.FC<EstimatedDistributionProps>  = (
                 .attr('id', 'title-header')
                 .call((g) => {
                     g.append('text')
-                        .attr('x', gWidth)
-                        .attr('y', 12)
+                        .attr('x', gWidth - 4)
+                        .attr('y', MARGIN + FONT_SIZE)
+                        .attr('paint-order', 'stroke')
+                        .attr('stroke', 'black')
+                        .attr('stroke-width', 4)
                         .attr('fill', 'white')
                         .attr('font-size', FONT_SIZE)
                         .attr('text-anchor', 'end')


### PR DESCRIPTION
This sort of comes down to preference. Without guidance this is where I thought it be best to move the p-value.
![Screenshot 2023-09-19 at 5 09 03 PM](https://github.com/ccnmtl/statify/assets/107073665/65bf9811-9615-4a39-b1f7-66d933f4c513)
